### PR TITLE
add -o after -prune when modifying files owner/group in batch

### DIFF
--- a/{{cookiecutter.project_slug}}/docker/centos/entrypoint.sh
+++ b/{{cookiecutter.project_slug}}/docker/centos/entrypoint.sh
@@ -58,10 +58,10 @@ else
     usermod --uid "$HOST_USERID" --gid "$HOST_GROUPID" "$SC_USER_NAME"
     
     echo "Changing group properties of files around from $SC_USER_ID to group $CONT_GROUPNAME"
-    find / -path /proc -prune -group "$SC_USER_ID" -exec chgrp --no-dereference "$CONT_GROUPNAME" {} \;
+    find / -path /proc -prune -o -group "$SC_USER_ID" -exec chgrp --no-dereference "$CONT_GROUPNAME" {} \;
     # change user property of files already around
     echo "Changing ownership properties of files around from $SC_USER_ID to group $CONT_GROUPNAME"
-    find / -path /proc -prune -user "$SC_USER_ID" -exec chown --no-dereference "$SC_USER_NAME" {} \;
+    find / -path /proc -prune -o -user "$SC_USER_ID" -exec chown --no-dereference "$SC_USER_NAME" {} \;
 fi
 
 echo "Starting $* ..."

--- a/{{cookiecutter.project_slug}}/docker/python/entrypoint.sh
+++ b/{{cookiecutter.project_slug}}/docker/python/entrypoint.sh
@@ -58,10 +58,10 @@ else
     usermod --uid "$HOST_USERID" --gid "$HOST_GROUPID" "$SC_USER_NAME"
     
     echo "Changing group properties of files around from $SC_USER_ID to group $CONT_GROUPNAME"
-    find / -path /proc -prune -group "$SC_USER_ID" -exec chgrp --no-dereference "$CONT_GROUPNAME" {} \;
+    find / -path /proc -prune -o -group "$SC_USER_ID" -exec chgrp --no-dereference "$CONT_GROUPNAME" {} \;
     # change user property of files already around
     echo "Changing ownership properties of files around from $SC_USER_ID to group $CONT_GROUPNAME"
-    find / -path /proc -prune -user "$SC_USER_ID" -exec chown --no-dereference "$SC_USER_NAME" {} \;
+    find / -path /proc -prune -o -user "$SC_USER_ID" -exec chown --no-dereference "$SC_USER_NAME" {} \;
 fi
 
 echo "Starting $* ..."

--- a/{{cookiecutter.project_slug}}/docker/ubuntu/entrypoint.sh
+++ b/{{cookiecutter.project_slug}}/docker/ubuntu/entrypoint.sh
@@ -58,10 +58,10 @@ else
     usermod --uid "$HOST_USERID" --gid "$HOST_GROUPID" "$SC_USER_NAME"
     
     echo "Changing group properties of files around from $SC_USER_ID to group $CONT_GROUPNAME"
-    find / -path /proc -prune -group "$SC_USER_ID" -exec chgrp --no-dereference "$CONT_GROUPNAME" {} \;
+    find / -path /proc -prune -o -group "$SC_USER_ID" -exec chgrp --no-dereference "$CONT_GROUPNAME" {} \;
     # change user property of files already around
     echo "Changing ownership properties of files around from $SC_USER_ID to group $CONT_GROUPNAME"
-    find / -path /proc -prune -user "$SC_USER_ID" -exec chown --no-dereference "$SC_USER_NAME" {} \;
+    find / -path /proc -prune -o -user "$SC_USER_ID" -exec chown --no-dereference "$SC_USER_NAME" {} \;
 fi
 
 echo "Starting $* ..."


### PR DESCRIPTION
<!--  **WIP-** prefix in title if still work in progress -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
- fixes not all files get their ownership/group membership modified correctly adding "-o" after "-prune" fixes it

## Related issue number

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you design a new module, add your user to .github/CODEOWNERS
