### PR TITLE
Remove coverage version restriction

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,7 +1,7 @@
 urllib3~=1.24.2  # https://nvd.nist.gov/vuln/detail/CVE-2019-11324
 jinja2~=2.10.1   # https://nvd.nist.gov/vuln/detail/CVE-2019-8341
 
-coverage==4.5.1 # TODO: Downgraded because of a bug https://github.com/nedbat/coveragepy/issues/716
+coverage
 cookiecutter
 coverage
 


### PR DESCRIPTION
This will cause a conflict in requirements and is no longer needed


## What do these changes do?

gets rid of the coverage version restriction which will cause a conflict in requirements

